### PR TITLE
fix OnQuestComputeXP

### DIFF
--- a/src/IndividualProgressionPlayer.cpp
+++ b/src/IndividualProgressionPlayer.cpp
@@ -113,13 +113,8 @@ public:
             uint32 vanillaXpValue = sIndividualProgression->questXpMap[quest->GetQuestId()];
             if (player)
             {
-                vanillaXpValue *= player->GetQuestRate();
-            }
-            // If XP was already reduced due to out-leveling the quest or other reasons, use the reduced value
-            if (vanillaXpValue < xpValue)
-            {
-                // Otherwise, return the correct Vanilla/TBC Quest XP
-                xpValue = vanillaXpValue;
+                uint32 originalXpValue = quest->XPValue(quest->GetQuestLevel() == -1 ? player->GetLevel() : quest->GetQuestLevel());
+                xpValue *= vanillaXpValue * 1.0 / originalXpValue;
             }
         }
     }


### PR DESCRIPTION
the heirloom equipment can not increase QuestXP after I use mod-individual-progression.
I found out where the problem was and fixed it.

According to the source code:
https://github.com/azerothcore/azerothcore-wotlk/blob/716a822b48218dd4dfa364dfb4d4f093ef957a42/src/server/game/Entities/Player/PlayerQuest.cpp#L737
XP value is affected by IsDFQuest, playerLevel and auras. Function OnQuestComputeXP is called after these calculations. 
So maybe we can  Scaling the xpValue by (vanillaXpValue/originalWLKVersionXpValue).

我发现OnQuestComputeXP的经验值计算忽略了（或者说是覆盖了）等级衰减、加经验值的光环效果（比如传家宝）的效果。所以提交一个PR来修复。